### PR TITLE
feat: Curios & L2backpack Compat

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,13 +1,3 @@
-buildscript {
-    repositories {
-        maven { url = 'https://maven.minecraftforge.net' }
-        mavenCentral()
-    }
-    dependencies {
-        classpath group: 'net.minecraftforge.gradle', name: 'ForgeGradle', version: '5.1.+', changing: true
-    }
-}
-
 plugins {
     id 'eclipse'
     id 'idea'
@@ -122,25 +112,26 @@ repositories {
     maven {
         url = "https://maven.theillusivec4.top/"
     }
+    maven { 
+        url = 'https://cursemaven.com' 
+    }
+    maven {
+        name = "Illusive Soulworks maven"
+        url = "https://maven.theillusivec4.top/"
+    }
 }
 
 dependencies {
-    minecraft([
-            group  : "net.minecraftforge",
-            name   : "forge",
-            version: "${project.mcversion}-${project.forgeversion}"
-    ])
+    minecraft "net.minecraftforge:forge:${mcversion}-${forgeversion}"
 
     compileOnly fg.deobf("mezz.jei:jei-${mcversion}-common-api:${jei_version}")
     compileOnly fg.deobf("mezz.jei:jei-${mcversion}-forge-api:${jei_version}")
     runtimeOnly fg.deobf("mezz.jei:jei-${mcversion}-forge:${jei_version}")
 
-    compileOnly fg.deobf([
-            group: "vazkii.botania",
-            name: "Botania",
-            version: "${project.botania}",
-            classifier: "api"
-    ])
+    compileOnly fg.deobf("vazkii.botania:Botania:${botania}:api")
+    compileOnly fg.deobf("curse.maven:l2-backpack-620229:${l2backpack_fileid}")
+    compileOnly fg.deobf("curse.maven:l2library-620203:${l2library_fileid}")
+    compileOnly(fg.deobf("top.theillusivec4.curios:curios-forge:${curios_version}:api"))
 }
 
 jar {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,4 @@
+org.gradle.java.home=C:/Program Files/Java/dragonwell-17.0.4.0.4+8-GA
 org.gradle.jvmargs=-Xmx3G
 org.gradle.daemon=false
 
@@ -5,14 +6,19 @@ author=thetadev
 modid=constructionwand
 
 mcversion=1.20.1
-forgeversion=47.0.19
+forgeversion=47.2.1
 mcp_channel=official
 mcp_mappings=1.20.1
 
 # Source: https://maven.blamejared.com/vazkii/botania/Botania/
 botania=1.20.1-441-FORGE-SNAPSHOT
 # Source: https://maven.blamejared.com/mezz/jei/
-jei_version=15.2.0.22
+jei_version=15.20.0.117
+
+l2backpack_fileid=7034933
+l2library_fileid=6806000
+
+curios_version=5.14.1+1.20.1
 
 version_major=2
-version_minor=12
+version_minor=13

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,5 +2,7 @@ pluginManagement {
     repositories {
         gradlePluginPortal()
         maven { url = 'https://maven.minecraftforge.net/' }
+        maven { url = 'https://cursemaven.com' }
+        maven { url = "https://maven.theillusivec4.top/"}
     }
 }

--- a/src/main/java/thetadev/constructionwand/ConstructionWand.java
+++ b/src/main/java/thetadev/constructionwand/ConstructionWand.java
@@ -20,7 +20,9 @@ import thetadev.constructionwand.client.RenderBlockPreview;
 import thetadev.constructionwand.containers.ContainerManager;
 import thetadev.constructionwand.containers.ContainerRegistrar;
 import thetadev.constructionwand.items.ModItems;
+import thetadev.constructionwand.network.PacketPreviewResult;
 import thetadev.constructionwand.network.PacketQueryUndo;
+import thetadev.constructionwand.network.PacketRequestPreview;
 import thetadev.constructionwand.network.PacketUndoBlocks;
 import thetadev.constructionwand.network.PacketWandOption;
 import thetadev.constructionwand.wand.undo.UndoHistory;
@@ -68,7 +70,9 @@ public class ConstructionWand
         int packetIndex = 0;
         HANDLER.registerMessage(packetIndex++, PacketUndoBlocks.class, PacketUndoBlocks::encode, PacketUndoBlocks::decode, PacketUndoBlocks.Handler::handle);
         HANDLER.registerMessage(packetIndex++, PacketQueryUndo.class, PacketQueryUndo::encode, PacketQueryUndo::decode, PacketQueryUndo.Handler::handle);
-        HANDLER.registerMessage(packetIndex, PacketWandOption.class, PacketWandOption::encode, PacketWandOption::decode, PacketWandOption.Handler::handle);
+        HANDLER.registerMessage(packetIndex++, PacketWandOption.class, PacketWandOption::encode, PacketWandOption::decode, PacketWandOption.Handler::handle);
+        HANDLER.registerMessage(packetIndex++, PacketRequestPreview.class, PacketRequestPreview::encode, PacketRequestPreview::decode, PacketRequestPreview.Handler::handle);
+        HANDLER.registerMessage(packetIndex, PacketPreviewResult.class, PacketPreviewResult::encode, PacketPreviewResult::decode, PacketPreviewResult.Handler::handle);
 
         // Container registry
         ContainerRegistrar.register();

--- a/src/main/java/thetadev/constructionwand/basics/WandUtil.java
+++ b/src/main/java/thetadev/constructionwand/basics/WandUtil.java
@@ -21,15 +21,22 @@ import net.minecraft.world.phys.shapes.VoxelShape;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.util.BlockSnapshot;
 import net.minecraftforge.event.level.BlockEvent;
+import net.minecraftforge.fml.ModList;
 import net.minecraftforge.registries.ForgeRegistries;
 import thetadev.constructionwand.ConstructionWand;
 import thetadev.constructionwand.containers.ContainerManager;
 import thetadev.constructionwand.items.wand.ItemWand;
 import thetadev.constructionwand.wand.WandItemUseContext;
+import top.theillusivec4.curios.api.CuriosApi;
+import top.theillusivec4.curios.api.type.capability.ICuriosItemHandler;
+import top.theillusivec4.curios.api.type.inventory.ICurioStacksHandler;
+
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.function.Predicate;
 
 public class WandUtil
@@ -80,9 +87,33 @@ public class WandUtil
         return player.getInventory().items.subList(9, player.getInventory().items.size());
     }
 
+    public static List<ItemStack> getArmor(Player player) {
+        return player.getInventory().armor;
+    }
+
+	public static List<ItemStack> getCuriosInv(Player player) {
+        List<ItemStack> result = new ArrayList<>();
+		if (ModList.get().isLoaded("curios")) {
+            CuriosApi.getCuriosInventory(player).ifPresent(handler -> {
+                Map<String, ICurioStacksHandler> curios = handler.getCurios();
+                for (ICurioStacksHandler slotHandler : curios.values()) {
+                    for (int i = 0; i < slotHandler.getSlots(); i++) {
+                        ItemStack stack = slotHandler.getStacks().getStackInSlot(i);
+                        if (!stack.isEmpty()) {
+                            result.add(stack);
+                        }
+                    }
+                }
+            });
+		}
+		return result;
+	}
+
     public static List<ItemStack> getFullInv(Player player) {
         ArrayList<ItemStack> inventory = new ArrayList<>(player.getInventory().offhand);
         inventory.addAll(player.getInventory().items);
+        inventory.addAll(player.getInventory().armor);
+        inventory.addAll(getCuriosInv(player));
         return inventory;
     }
 

--- a/src/main/java/thetadev/constructionwand/client/RenderBlockPreview.java
+++ b/src/main/java/thetadev/constructionwand/client/RenderBlockPreview.java
@@ -41,7 +41,7 @@ public class RenderBlockPreview
         ItemStack wand = WandUtil.holdingWand(player);
         if(wand == null) return;
 
-        if (player.isCrouching() || ClientEvents.isOptKeyDown()) {
+        if (player.isCrouching() && ClientEvents.isOptKeyDown()) {
             blocks = undoBlocks;
             colorG = 1;
         }

--- a/src/main/java/thetadev/constructionwand/client/RenderBlockPreview.java
+++ b/src/main/java/thetadev/constructionwand/client/RenderBlockPreview.java
@@ -16,14 +16,17 @@ import net.minecraftforge.client.event.RenderHighlightEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import thetadev.constructionwand.basics.WandUtil;
 import thetadev.constructionwand.items.wand.ItemWand;
-import thetadev.constructionwand.wand.WandJob;
+import thetadev.constructionwand.network.PacketRequestPreview;
+import thetadev.constructionwand.ConstructionWand;
 
 import java.util.Set;
 
 public class RenderBlockPreview
 {
-    private WandJob wandJob;
+    private BlockHitResult lastRayTraceResult = null;
+    private ItemStack lastWand = ItemStack.EMPTY;
     public Set<BlockPos> undoBlocks;
+    public Set<BlockPos> previewBlocks;
 
     @SubscribeEvent
     public void renderBlockHighlight(RenderHighlightEvent.Block event) {
@@ -38,19 +41,21 @@ public class RenderBlockPreview
         ItemStack wand = WandUtil.holdingWand(player);
         if(wand == null) return;
 
-        if(!(player.isCrouching() && ClientEvents.isOptKeyDown())) {
+        if (player.isCrouching() || ClientEvents.isOptKeyDown()) {
+            blocks = undoBlocks;
+            colorG = 1;
+        }
+        else {
             // Use cached wandJob for previews of the same target pos/dir
             // Exception: always update if blockCount < 2 to prevent 1-block previews when block updates
             // from the last placement are lagging
-            if(wandJob == null || !compareRTR(wandJob.rayTraceResult, rtr) || !(wandJob.wand.equals(wand))
-                || wandJob.blockCount() < 2) {
-                wandJob = ItemWand.getWandJob(player, player.level(), rtr, wand);
+            if(lastRayTraceResult == null || !compareRTR(lastRayTraceResult, rtr) || lastWand.equals(wand)
+                || previewBlocks.size() < 2) {
+                lastRayTraceResult = rtr;
+                lastWand = wand;
+                ConstructionWand.instance.HANDLER.sendToServer(new PacketRequestPreview(rtr, wand));
             }
-            blocks = wandJob.getBlockPositions();
-        }
-        else {
-            blocks = undoBlocks;
-            colorG = 1;
+            blocks = previewBlocks;
         }
 
         if(blocks == null || blocks.isEmpty()) return;
@@ -73,7 +78,9 @@ public class RenderBlockPreview
     }
 
     public void reset() {
-        wandJob = null;
+        lastRayTraceResult = null;
+        lastWand = ItemStack.EMPTY;
+        previewBlocks = null;
     }
 
     private static boolean compareRTR(BlockHitResult rtr1, BlockHitResult rtr2) {

--- a/src/main/java/thetadev/constructionwand/containers/ContainerRegistrar.java
+++ b/src/main/java/thetadev/constructionwand/containers/ContainerRegistrar.java
@@ -5,6 +5,7 @@ import thetadev.constructionwand.ConstructionWand;
 import thetadev.constructionwand.containers.handlers.HandlerBotania;
 import thetadev.constructionwand.containers.handlers.HandlerBundle;
 import thetadev.constructionwand.containers.handlers.HandlerCapability;
+import thetadev.constructionwand.containers.handlers.HandlerLightland;
 import thetadev.constructionwand.containers.handlers.HandlerShulkerbox;
 
 public class ContainerRegistrar
@@ -17,6 +18,15 @@ public class ContainerRegistrar
         if(ModList.get().isLoaded("botania")) {
             ConstructionWand.instance.containerManager.register(new HandlerBotania());
             ConstructionWand.LOGGER.info("Botania integration added");
+        }
+
+        if(ModList.get().isLoaded("l2backpack")) {
+            ConstructionWand.instance.containerManager.register(new HandlerLightland());
+            ConstructionWand.LOGGER.info("L2Backpack integration added");
+        }
+
+        if(ModList.get().isLoaded("curios")) {
+            ConstructionWand.LOGGER.info("Curios integration added");
         }
     }
 }

--- a/src/main/java/thetadev/constructionwand/containers/ContainerRegistrar.java
+++ b/src/main/java/thetadev/constructionwand/containers/ContainerRegistrar.java
@@ -11,6 +11,12 @@ import thetadev.constructionwand.containers.handlers.HandlerShulkerbox;
 public class ContainerRegistrar
 {
     public static void register() {
+        // Normal backpack will be recognized as Capability
+        if(ModList.get().isLoaded("l2backpack")) {
+            ConstructionWand.instance.containerManager.register(new HandlerLightland());
+            ConstructionWand.LOGGER.info("L2Backpack integration added");
+        }
+
         ConstructionWand.instance.containerManager.register(new HandlerCapability());
         ConstructionWand.instance.containerManager.register(new HandlerShulkerbox());
         ConstructionWand.instance.containerManager.register(new HandlerBundle());
@@ -18,11 +24,6 @@ public class ContainerRegistrar
         if(ModList.get().isLoaded("botania")) {
             ConstructionWand.instance.containerManager.register(new HandlerBotania());
             ConstructionWand.LOGGER.info("Botania integration added");
-        }
-
-        if(ModList.get().isLoaded("l2backpack")) {
-            ConstructionWand.instance.containerManager.register(new HandlerLightland());
-            ConstructionWand.LOGGER.info("L2Backpack integration added");
         }
 
         if(ModList.get().isLoaded("curios")) {

--- a/src/main/java/thetadev/constructionwand/containers/handlers/HandlerLightland.java
+++ b/src/main/java/thetadev/constructionwand/containers/handlers/HandlerLightland.java
@@ -1,0 +1,104 @@
+package thetadev.constructionwand.containers.handlers;
+
+import dev.xkmc.l2backpack.content.capability.PickupModeCap;
+import dev.xkmc.l2backpack.content.capability.InvPickupCap;
+import dev.xkmc.l2backpack.content.capability.PickupTrace;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.items.IItemHandlerModifiable;
+import thetadev.constructionwand.ConstructionWand;
+import thetadev.constructionwand.api.IContainerHandler;
+import thetadev.constructionwand.basics.WandUtil;
+
+public class HandlerLightland implements IContainerHandler {
+
+    @Override
+    public boolean matches(Player player, ItemStack itemStack, ItemStack inventoryStack) {
+        return resolveInvCap(inventoryStack) != null;
+    }
+
+    @Override
+    public int countItems(Player player, ItemStack itemStack, ItemStack inventoryStack) {
+        if (!(player instanceof ServerPlayer sp)) return 0;
+        InvPickupCap<?> cap = resolveInvCap(inventoryStack);
+        if (cap == null) return 0;
+
+        PickupTrace trace = new PickupTrace(false, sp);
+        if (!trace.push(cap.getSignature(), null)) return 0;
+        int result = countRecursive(cap, trace, itemStack, Integer.MAX_VALUE);
+        trace.pop();
+        return result;
+    }
+
+    @Override
+    public int useItems(Player player, ItemStack itemStack, ItemStack inventoryStack, int count) {
+        if (!(player instanceof ServerPlayer sp)) return count;
+        InvPickupCap<?> cap = resolveInvCap(inventoryStack);
+        if (cap == null) return count;
+
+        PickupTrace trace = new PickupTrace(false, sp);
+        if (!trace.push(cap.getSignature(), null)) return count;
+        int result = extractRecursive(cap, trace, itemStack, count);
+        trace.pop();
+        return result;
+    }
+
+    private InvPickupCap<?> resolveInvCap(ItemStack stack) {
+        return stack.getCapability(PickupModeCap.TOKEN)
+            .resolve()
+            .filter(c -> c instanceof InvPickupCap<?>)
+            .map(c -> (InvPickupCap<?>) c)
+            .orElse(null);
+    }
+
+    private int countRecursive(InvPickupCap<?> cap, PickupTrace trace, ItemStack target, int maxCount) {
+        IItemHandlerModifiable inv = cap.getInv(trace);
+        if (inv == null) return 0;
+        int found = 0;
+
+        for (int i = 0; i < inv.getSlots(); i++) {
+            ItemStack stack = inv.getStackInSlot(i);
+            if (WandUtil.stackEquals(target, stack)) {
+                //ConstructionWand.LOGGER.info("Stack Dectect: " + stack.toString());
+                found += stack.getCount();
+                if (found >= maxCount) return maxCount;
+            }
+
+            InvPickupCap<?> nested = resolveInvCap(stack);
+            if (nested != null && trace.push(nested.getSignature(), null)) {
+                //ConstructionWand.LOGGER.info("Nested Dectect: " + stack.toString());
+                found += countRecursive(nested, trace, target, maxCount - found);
+                trace.pop();
+                if (found >= maxCount) return maxCount;
+            }
+        }
+
+        return found;
+    }
+
+    private int extractRecursive(InvPickupCap<?> cap, PickupTrace trace, ItemStack target, int count) {
+        IItemHandlerModifiable inv = cap.getInv(trace);
+        if (inv == null) return count;
+        int remaining = count;
+
+        for (int i = 0; i < inv.getSlots(); i++) {
+            ItemStack stack = inv.getStackInSlot(i);
+            if (WandUtil.stackEquals(target, stack)) {
+                int extractable = Math.min(stack.getCount(), remaining);
+                ItemStack extracted = inv.extractItem(i, extractable, false);
+                remaining -= extracted.getCount();
+                if (remaining <= 0) return 0;
+            }
+
+            InvPickupCap<?> nested = resolveInvCap(stack);
+            if (nested != null && trace.push(nested.getSignature(), null)) {
+                remaining = extractRecursive(nested, trace, target, remaining);
+                trace.pop();
+                if (remaining <= 0) return 0;
+            }
+        }
+
+        return remaining;
+    }
+}

--- a/src/main/java/thetadev/constructionwand/network/PacketPreviewResult.java
+++ b/src/main/java/thetadev/constructionwand/network/PacketPreviewResult.java
@@ -1,0 +1,45 @@
+package thetadev.constructionwand.network;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraftforge.network.NetworkEvent;
+import thetadev.constructionwand.ConstructionWand;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.Supplier;
+
+
+public class PacketPreviewResult {
+    public final Set<BlockPos> previewBlocks;
+
+    public PacketPreviewResult(Set<BlockPos> previewBlocks) {
+        this.previewBlocks = new HashSet<>(previewBlocks);
+    }
+
+    private PacketPreviewResult(HashSet<BlockPos> previewBlocks) {
+        this.previewBlocks = previewBlocks;
+    }
+
+    public static void encode(PacketPreviewResult msg, FriendlyByteBuf buffer) {
+        for (BlockPos pos : msg.previewBlocks) {
+            buffer.writeBlockPos(pos);
+        }
+    }
+
+    public static PacketPreviewResult decode(FriendlyByteBuf buffer) {
+        HashSet<BlockPos> previewBlocks = new HashSet<>();
+        while (buffer.isReadable()) {
+            previewBlocks.add(buffer.readBlockPos());
+        }
+        return new PacketPreviewResult(previewBlocks);
+    }
+
+    public static class Handler {
+        public static void handle(final PacketPreviewResult msg, final Supplier<NetworkEvent.Context> ctx) {
+            if (!ctx.get().getDirection().getReceptionSide().isClient()) return;
+            ConstructionWand.instance.renderBlockPreview.previewBlocks = msg.previewBlocks;
+            ctx.get().setPacketHandled(true);
+        }
+    }
+}

--- a/src/main/java/thetadev/constructionwand/network/PacketRequestPreview.java
+++ b/src/main/java/thetadev/constructionwand/network/PacketRequestPreview.java
@@ -1,0 +1,58 @@
+package thetadev.constructionwand.network;
+
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.network.protocol.game.ClientboundCustomPayloadPacket;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.world.phys.BlockHitResult;
+import net.minecraftforge.network.NetworkEvent;
+import net.minecraftforge.network.PacketDistributor;
+import thetadev.constructionwand.items.wand.ItemWand;
+import thetadev.constructionwand.wand.WandJob;
+import thetadev.constructionwand.ConstructionWand;
+
+import java.util.Set;
+import java.util.function.Supplier;
+
+
+public class PacketRequestPreview {
+    private final BlockHitResult rtr;
+    private final ItemStack wand;
+
+    public PacketRequestPreview(BlockHitResult rtr, ItemStack wand) {
+        this.rtr = rtr;
+        this.wand = wand;
+    }
+
+    public static void encode(PacketRequestPreview msg, FriendlyByteBuf buf) {
+        buf.writeItem(msg.wand);
+        buf.writeBlockHitResult(msg.rtr);
+    }
+
+    public static PacketRequestPreview decode(FriendlyByteBuf buf) {
+        ItemStack wand = buf.readItem();
+        BlockHitResult rtr = buf.readBlockHitResult();
+        return new PacketRequestPreview(rtr, wand);
+    }
+
+    public static class Handler
+    {
+        public static void handle(PacketRequestPreview msg, Supplier<NetworkEvent.Context> ctx) {
+            ctx.get().enqueueWork(() -> {
+                ServerPlayer player = ctx.get().getSender();
+                if (player == null) return;
+
+                WandJob job = ItemWand.getWandJob(player, player.level(), msg.rtr, msg.wand);
+                Set<BlockPos> blocks = job.getBlockPositions();
+
+                ConstructionWand.instance.HANDLER.send(
+                    PacketDistributor.PLAYER.with(() -> player),
+                    new PacketPreviewResult(blocks)
+                );
+            });
+            ctx.get().setPacketHandled(true);
+        }
+    }
+}

--- a/src/main/java/thetadev/constructionwand/wand/supplier/SupplierInventory.java
+++ b/src/main/java/thetadev/constructionwand/wand/supplier/SupplierInventory.java
@@ -110,6 +110,9 @@ public class SupplierInventory implements IWandSupplier
 
         List<ItemStack> hotbar = WandUtil.getHotbarWithOffhand(player);
         List<ItemStack> mainInv = WandUtil.getMainInv(player);
+        List<ItemStack> armor = WandUtil.getArmor(player);
+        List<ItemStack> curios = WandUtil.getCuriosInv(player);
+    
 
         // Take items from main inv, loose items first
         count = takeItemsInvList(count, item, mainInv, false);
@@ -118,6 +121,12 @@ public class SupplierInventory implements IWandSupplier
         // Take items from hotbar, containers first
         count = takeItemsInvList(count, item, hotbar, true);
         count = takeItemsInvList(count, item, hotbar, false);
+
+        count = takeItemsInvList(count, item, armor, true);
+        count = takeItemsInvList(count, item, armor, false);    
+
+        count = takeItemsInvList(count, item, curios, true);
+        count = takeItemsInvList(count, item, curios, false); 
 
         return count;
     }


### PR DESCRIPTION
This PR does four things:
1. Handler [Lightland Backpack](https://github.com/Minecraft-LightLand/L2Backpack), as this mod does not use items with NBT to store data, but outside. That means the original handler cannot deal. If trying to deal with them like a normal capability, it will easily fall into an endless rabbit hole.
2. To preview it, blocks in RenderBlockPreview must be calculated on the server side.
3. To allow backpacks on armor and curios slots to work, WandUtil and SupplierInventory also change slightly.
4. Problem: If a block appears on armor slots (like a player head), it will be placed. If the same backpack appears in the inventory, blocks in RenderBlockPreview will be multiplied.